### PR TITLE
Add htmlspecialchars to a bunch of print statements

### DIFF
--- a/access-portal/backend/doneeDonationAmountsByDonorAndYear.inc
+++ b/access-portal/backend/doneeDonationAmountsByDonorAndYear.inc
@@ -1,6 +1,6 @@
 <?php
 
-print '<h4 id="doneeDonationAmountsByDonorAndYear">Donation amounts by donor and year for donee '.$donee.'</h4>'."\n";
+print '<h4 id="doneeDonationAmountsByDonorAndYear">Donation amounts by donor and year for donee '.htmlspecialchars($donee).'</h4>'."\n";
 
 $donorQuery = "select donor from donations where donee = ? group by donor;";
 $stmt = $mysqli->prepare($donorQuery);

--- a/access-portal/backend/donorInfo.inc
+++ b/access-portal/backend/donorInfo.inc
@@ -7,7 +7,7 @@ $donorSelectResult = $stmt->get_result();
 $affiliatedOrgsList = array();
 print '<h4 id="donorInfo">Basic donor information</h4>';
 if ($donorSelectResult -> num_rows == 0) {
-  print "<p>We do not have any donor information for the donor $donor in our system.";
+  print "<p>We do not have any donor information for the donor " . htmlspecialchars($donor) . " in our system.";
 } else {
   $row = $donorSelectResult -> fetch_assoc();
   print "\n";

--- a/access-portal/backend/influencerDonationAmountsByDonorAndYear.inc
+++ b/access-portal/backend/influencerDonationAmountsByDonorAndYear.inc
@@ -12,7 +12,7 @@ function linkDonees(string $doneeList, string $donor) {
 }
 
 
-print '<h4 id="influencerDonationAmountsByDonorAndYear">Donation amounts by donor and year for influencer '.$influencer.'</h4>'."\n";
+print '<h4 id="influencerDonationAmountsByDonorAndYear">Donation amounts by donor and year for influencer '.htmlspecialchars($influencer).'</h4>'."\n";
 
 $query = "select donor, group_concat(distinct donee order by donee separator '|') as donee_list from donations where influencer regexp ?";
 $paramStr = "s";

--- a/access-portal/backend/influencerMoneyMovedList.inc
+++ b/access-portal/backend/influencerMoneyMovedList.inc
@@ -103,7 +103,7 @@ while ($row = $result->fetch_assoc()) {
 }
 
 if ($amountClaimedNumRows > 0) {
-  print '<h4 id="influencerMoneyMovedList">Money moved infomation for influencer '.$influencer.' (' . $amountClaimedNumRows . ' rows)</h4>';
+  print '<h4 id="influencerMoneyMovedList">Money moved infomation for influencer '.htmlspecialchars($influencer).' (' . $amountClaimedNumRows . ' rows)</h4>';
   print '<table id="myTableInfluencerMoneyMovedList" class="tablesorter">'."\n";
   print "<thead>\n";
   print "<tr>\n";

--- a/access-portal/backend/stringFunctions.inc
+++ b/access-portal/backend/stringFunctions.inc
@@ -20,7 +20,7 @@ function printDonationDate($donationDate, $donationDatePrecision, $donationDateB
   } else if ($donationDatePrecision == 'year' or $donationDatePrecision == 'multi-year') {
     $donationDate = substr($donationDate,0,4);
   }
-  print '<td align="left"><element title="'.$donationDatePrecision.' precision, based on '.$donationDateBasis.'">'.$donationDate.'</element></td>';
+  print '<td align="left"><element title="'.htmlspecialchars($donationDatePrecision).' precision, based on '.htmlspecialchars($donationDateBasis).'">'.htmlspecialchars($donationDate).'</element></td>';
 }
 
 function printAmountWithRank($amount, $amountList, $amountOriginalCurrency, $originalCurrency) {
@@ -31,8 +31,8 @@ function printAmountWithRank($amount, $amountList, $amountOriginalCurrency, $ori
     } else {
       $originalCurrStr = "";
     }
-    print '<td align="right"' . $originalCurrStr . '>'.number_format($amount,2).'</td>';
-    print '<td align="right">'.(array_search($amount, array_reverse($amountList)) + 1).'</td>';
+    print '<td align="right"' . htmlspecialchars($originalCurrStr) . '>'.htmlspecialchars(number_format($amount,2)).'</td>';
+    print '<td align="right">'.htmlspecialchars(array_search($amount, array_reverse($amountList)) + 1).'</td>';
 }
 
 function cleanNotes($notes) {

--- a/access-portal/backend/yearlyDisclosures.inc
+++ b/access-portal/backend/yearlyDisclosures.inc
@@ -37,8 +37,8 @@ function filteredDonorCauseArea($mysqli, $query1, $query2, $donor,
     return $result;
   } else {
     print "<pre>";
-    print 'DEBUG: ' . $mysqli->error . "\n";
-    print "DEBUG: Query was: " . $query . "\n";
+    print 'DEBUG: ' . htmlspecialchars($mysqli->error) . "\n";
+    print "DEBUG: Query was: " . htmlspecialchars($query) . "\n";
     print "</pre>\n";
   }
 }

--- a/access-portal/backend/yearlyGroupings.inc
+++ b/access-portal/backend/yearlyGroupings.inc
@@ -41,7 +41,7 @@ EOD;
 
 function printFooterRow($data, $years, $rowName, $rowLabel) {
   print "  <tr>\n";
-  print "    <td><strong>$rowLabel</strong></td>\n";
+  print "    <td><strong>" . htmlspecialchars($rowLabel) . "</strong></td>\n";
   print '    <td align="right"><strong>'
     . ($data['numDonations'][$rowName]['Total'] ?? 0)
     . "</strong></td>\n";
@@ -263,13 +263,13 @@ function printYearlyGroupedHtmlTable(
 ) {
 
   $donorString = $donor ? "donor" : "";
-  print '<h4 id="' . $donorString . ($donorString ? 'Donation' : 'donation')
-    . 'AmountsBy' . camelCaseStripSpace($groupName)
-    . 'AndYear">' . "Donation amounts by $groupName and year</h4>";
+  print '<h4 id="' . htmlspecialchars($donorString) . ($donorString ? 'Donation' : 'donation')
+    . 'AmountsBy' . urlencode(camelCaseStripSpace($groupName))
+    . 'AndYear">' . "Donation amounts by " . htmlspecialchars($groupName) . " and year</h4>";
 
   if (($data['amount']['Classified']['Total'] ?? 0) > 0) {
 
-    print "<p>If you hover over a cell for a given $groupName and year, "
+    print "<p>If you hover over a cell for a given " . htmlspecialchars($groupName) . " and year, "
       . "you will get a tooltip with the number of donees and the number of "
       . "donations.</p>\n";
 

--- a/access-portal/donee.php
+++ b/access-portal/donee.php
@@ -26,7 +26,7 @@ if ($result->num_rows > 0) {
   die();
 }
 
-print "<title>$donee donations received</title>";
+print "<title>" . htmlspecialchars($donee) . " donations received</title>";
 include_once('analytics.inc');
 include_once('strip-commas.inc');
 include_once('backend/stringFunctions.inc');
@@ -46,7 +46,7 @@ print '<script>$(document).ready(function()
         $("#myTableDoneeDonationList").tablesorter({textExtraction: stripCommas});
     }
 ); </script>'."\n";
-print "<h3>$donee donations received</h3>";
+print "<h3>" . htmlspecialchars($donee) . " donations received</h3>";
 ?>
 
 <p><span id="changeThemeMenu" style="display: none;">Set color scheme to:

--- a/access-portal/donor.php
+++ b/access-portal/donor.php
@@ -32,7 +32,7 @@ if (!empty($_REQUEST['cause_area_filter'])) {
   $causeAreaFilterString = $_REQUEST['cause_area_filter'];
   $causeAreaFilterStringHelper = " (filtered to cause areas matching $causeAreaFilterString)";
 }
-print "<title>$donor donations made $causeAreaFilterStringHelper</title>";
+print "<title>" . htmlspecialchars($donor) . " donations made " . htmlspecialchars($causeAreaFilterStringHelper) . "</title>";
 include_once('analytics.inc');
 include_once('strip-commas.inc');
 include_once('backend/stringFunctions.inc');
@@ -57,7 +57,7 @@ print '<script>$(document).ready(function()
         $("#myTableDonorSimilarDonors").tablesorter({textExtraction: stripCommas});
     }
 ); </script>'."\n";
-print "<h3>$donor donations made $causeAreaFilterStringHelper</h3>";
+print "<h3>" . htmlspecialchars($donor) . " donations made " . htmlspecialchars($causeAreaFilterStringHelper) . "</h3>";
 ?>
 
 <p><span id="changeThemeMenu" style="display: none;">Set color scheme to:

--- a/access-portal/donorDonee.php
+++ b/access-portal/donorDonee.php
@@ -55,8 +55,8 @@ if (!empty($_REQUEST['cause_area_filter'])) {
   $causeAreaFilterString = '';
 }
 
-print "<title>$donor donations made to $donee"
-  . ($causeAreaFilterString ? " (filtered to cause areas matching $causeAreaFilterString)" : '')
+print "<title>" . htmlspecialchars($donor) . " donations made to " . htmlspecialchars($donee)
+  . htmlspecialchars($causeAreaFilterString ? " (filtered to cause areas matching $causeAreaFilterString)" : '')
   . "</title>";
 include_once('analytics.inc');
 include_once('strip-commas.inc');
@@ -74,8 +74,8 @@ print '<script>$(document).ready(function()
         $("table").tablesorter({textExtraction: stripCommas});
     }
 ); </script>'."\n";
-print "<h3>$donor donations made to $donee"
-  . ($causeAreaFilterString ? " (filtered to cause areas matching $causeAreaFilterString)" : '')
+print "<h3>" . htmlspecialchars($donor) . " donations made to " . htmlspecialchars($donee)
+  . htmlspecialchars($causeAreaFilterString ? " (filtered to cause areas matching $causeAreaFilterString)" : '')
  . "</h3>";
 ?>
 
@@ -104,9 +104,9 @@ if (needToRegenerate($cache_location)) {
   if (sys_getloadavg()[0] <= 1.10) {
     ob_start();
     include ("backend/donorInfo.inc");
-    print '<p><a href="/donor.php?donor='.urlencode($donor).'">Full donor page for donor '.$donor.'</a></p>'."\n";
+    print '<p><a href="/donor.php?donor='.urlencode($donor).'">Full donor page for donor '.htmlspecialchars($donor).'</a></p>'."\n";
     include ("backend/doneeInfo.inc");
-    print '<p><a href="/donee.php?donee='.urlencode($donee).'">Full donee page for donee '.$donee.'</a></p>'."\n";
+    print '<p><a href="/donee.php?donee='.urlencode($donee).'">Full donee page for donee '.htmlspecialchars($donee).'</a></p>'."\n";
     include ("backend/donorDoneeRelationship.inc");
     include ("backend/donorDoneeStatistics.inc");
     include ("backend/donorDoneeDonationAmountsByCauseAreaAndYear.inc");

--- a/access-portal/index.php
+++ b/access-portal/index.php
@@ -11,7 +11,7 @@ if (!empty($_REQUEST['cause_area_filter'])) {
   $causeAreaFilterString = $_REQUEST['cause_area_filter'];
   $causeAreaFilterStringHelper = " (filtered to cause areas matching $causeAreaFilterString)";
 }
-print "<title>Donations list website $causeAreaFilterStringHelper</title>";
+print "<title>Donations list website " . htmlspecialchars($causeAreaFilterStringHelper) . "</title>";
 print '<link href="style.css" rel="stylesheet" type="text/css" />'."\n";
 include_once("style.inc");
 print '<script type="text/javascript" src="./jquery-3.7.1.min.js"></script>'."\n";
@@ -30,7 +30,7 @@ print '<script>$(document).ready(function()
         $("#myTableDonationAmountsByDisclosuresAndYear").tablesorter({textExtraction: stripCommas});
     }
 ); </script>'."\n";
-print "<h3>Donations recorded by Vipul Naik $causeAreaFilterStringHelper</h3>";
+print "<h3>Donations recorded by Vipul Naik " . htmlspecialchars($causeAreaFilterStringHelper) . "</h3>";
 ?>
 
 <p><span id="changeThemeMenu" style="display: none;">Set color scheme to:

--- a/access-portal/influencer.php
+++ b/access-portal/influencer.php
@@ -4,7 +4,7 @@ $influencer = 'GiveWell';
 if (!empty($_REQUEST['influencer'])) {
   $influencer = $_REQUEST['influencer'];
 }
-print "<title>$influencer money moved</title>";
+print "<title>" . htmlspecialchars($influencer) . " money moved</title>";
 include_once('analytics.inc');
 print '<script src="change-theme.js"></script>';
 include_once('strip-commas.inc');
@@ -28,7 +28,7 @@ print '<script>$(document).ready(function()
         $("#myTableInfluencerDonationAmountsByDonorAndYear").tablesorter({textExtraction: stripCommas});
     }
 ); </script>'."\n";
-print "<h3>$influencer money moved</h3>";
+print "<h3>" . htmlspecialchars($influencer) . " money moved</h3>";
 ?>
 
 <p><span id="changeThemeMenu" style="display: none;">Set color scheme to:

--- a/similarity/compute_similarity.php
+++ b/similarity/compute_similarity.php
@@ -95,7 +95,7 @@ foreach ($donors as $donor) {
     $stmt->execute();
     $result = $stmt->get_result();
 
-    print "Doing $donor\n";
+    print "Doing " . htmlspecialchars($donor) . "\n";
     if ((! $result) || ($result->num_rows <= 0)) {
       printf("<p>Sorry, we couldn't find any similar donors.</p>");
     } else {


### PR DESCRIPTION
I did all the searching from within Vim, so the commands listed below will be in Vim's regex variant. But you can do the same thing in just normal grep too.

```vim
:vim /_REQUEST/ access-portal/**/*
```

I started by looking at all variables defined via `_REQUEST`, since that's where malicious inputs could come in. But it was annoying to try to keep track of all the variable names and follow them, so after a while I switched to:

```vim
:vim /\(print\|echo\).*\$/ **/*.php
:vim /\(print\|echo\).*\$/ **/*.inc
```

This searches for all print/echo calls that make use of any variable (since variables in PHP start with a `$`). This produced several hundred matches across both commands (I think roughly 400) and I just manually looked through every single one. If a print/echo command used a variable that did _not_ come from the database (I assumed are values in the database are safe since they are manually entered by us), then I wrapped it in `htmlspecialchars` or in cases where the variable was meant to be part of a URL I used `urlencode`.